### PR TITLE
Added check for InternaIP

### DIFF
--- a/pkg/nfs/provision.go
+++ b/pkg/nfs/provision.go
@@ -466,7 +466,7 @@ func (p *nfsProvisioner) createExport(directory string, FilesystemID int64, conf
 	for _, node := range nodelist {
 		for _, naddress := range node.Status.Addresses {
 			addr := net.ParseIP(naddress.Address)
-			if addr != nil {
+			if addr != nil  && naddress.Type=="InternalIP" {
 				permissionsput = append(permissionsput, map[string]interface{}{"access": acess, "no_root_squash": rootsq, "client": addr})
 
 			}


### PR DESCRIPTION
Patch added to existing nfs/provision.go which will only use InternalIP while adding rule to export post creation of file-system.